### PR TITLE
Update manifest.json

### DIFF
--- a/gigawallet/manifest.json
+++ b/gigawallet/manifest.json
@@ -37,7 +37,7 @@
           "gigawallet-public"
         ],
         "listenOnHost": true,
-        "webUI": false
+        "webUI": true
       },
       {
         "name": "admin-port",
@@ -46,8 +46,8 @@
         "interfaces": [
           "gigawallet-admin"
         ],
-        "listenOnHost": false,
-        "webUI": false
+        "listenOnHost": true,
+        "webUI": true
       }
     ],
     "requiresInternet": true


### PR DESCRIPTION
im working on a wordpress website and trying to use gigawallet
i think this change will let me access gigawallet via port 8081 and 8082